### PR TITLE
Bump marimo to 0.23.4; click to 8.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,3 @@ WORKDIR /home/${NB_USER}
 EXPOSE 8888
 
 ENTRYPOINT ["tini", "--"]
-
-

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - liblapack=3.9.0
   - armadillo==14.6.0
   - gperf==3.1
-  # CS 16A
+  # EECS 16A
   # From https://github.com/berkeley-dsep-infra/datahub/issues/1363#issuecomment-598916469
   - sympy==1.14.0
   - pyaudio==0.2.14
@@ -49,6 +49,6 @@ dependencies:
       - git+https://github.com/shaneknapp/python-popularity-contest.git@add-error-handling
       - git-credential-helpers==0.2
       # Marimo integration for EECS 16A
-      - marimo==0.14.16
-      - click==8.2.1
+      - marimo==0.23.4
+      - click==8.3.3
       - git+https://github.com/b-data/jupyter-marimo-proxy.git@jupyterlab-docker-stack


### PR DESCRIPTION
Bumping Marimo to 0.23.4 to address CVE-2026-39987 (https://nvd.nist.gov/vuln/detail/CVE-2026-39987).  Bumping click to 8.3.3.